### PR TITLE
add timestamps to date helpers results

### DIFF
--- a/build/Charts/utils/dateHelpers.js
+++ b/build/Charts/utils/dateHelpers.js
@@ -1,7 +1,7 @@
 import moment from 'moment'; //  time ranges relative to current day
 
 var today = function today() {
-  return [moment.utc(), moment.utc()];
+  return [moment.utc().startOf('day'), moment.utc().endOf('day')];
 };
 
 var thisWeek = function thisWeek() {
@@ -18,7 +18,7 @@ var thisYear = function thisYear() {
 
 
 var yesterday = function yesterday() {
-  return [moment.utc().subtract(1, 'day'), moment.utc().subtract(1, 'day')];
+  return [moment.utc().startOf('day').subtract(1, 'day'), moment.utc().endOf('day').subtract(1, 'day')];
 };
 
 var lastWeek = function lastWeek() {
@@ -35,6 +35,11 @@ var lastYear = function lastYear() {
 
 var last12Months = function last12Months() {
   return [moment.utc().subtract(12, 'month').startOf('month'), moment.utc().startOf('month')];
+}; // Add timestamps to dates
+
+
+var custom = function custom(startDate, endDate) {
+  return [moment.utc(startDate).startOf('day'), moment.utc(endDate).endOf('day')];
 };
 
 export default {
@@ -49,5 +54,6 @@ export default {
   lastWeek: lastWeek,
   lastMonth: lastMonth,
   lastYear: lastYear,
-  last12Months: last12Months
+  last12Months: last12Months,
+  custom: custom
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podium-reporting-toolkit",
-  "version": "0.16.7",
+  "version": "0.16.8",
   "description": "A collection of Podium's reporting platform and charting components built in React.",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/src/Charts/utils/dateHelpers.js
+++ b/src/Charts/utils/dateHelpers.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 //  time ranges relative to current day
-const today = () => [moment.utc(), moment.utc()];
+const today = () => [moment.utc().startOf('day'), moment.utc().endOf('day')];
 
 const thisWeek = () => [
   moment
@@ -17,8 +17,14 @@ const thisYear = () => [moment.utc().startOf('year'), moment.utc()];
 
 // time ranges relative to day in the past
 const yesterday = () => [
-  moment.utc().subtract(1, 'day'),
-  moment.utc().subtract(1, 'day')
+  moment
+    .utc()
+    .startOf('day')
+    .subtract(1, 'day'),
+  moment
+    .utc()
+    .endOf('day')
+    .subtract(1, 'day')
 ];
 
 const lastWeek = () => [
@@ -64,6 +70,12 @@ const last12Months = () => [
   moment.utc().startOf('month')
 ];
 
+// Add timestamps to dates
+const custom = (startDate, endDate) => [
+  moment.utc(startDate).startOf('day'),
+  moment.utc(endDate).endOf('day')
+];
+
 export default {
   today,
   thisWeek,
@@ -76,5 +88,6 @@ export default {
   lastWeek,
   lastMonth,
   lastYear,
-  last12Months
+  last12Months,
+  custom
 };

--- a/src/__tests__/dateHelpers.test.js
+++ b/src/__tests__/dateHelpers.test.js
@@ -1,0 +1,49 @@
+import dateHelpers from '../Charts/utils/dateHelpers';
+
+describe('Preset Range', () => {
+  let momentMock;
+
+  beforeAll(() => {
+    // freeze time: September 13, 2019 @ 6:00 AM
+    momentMock = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => 1568354400000);
+  });
+
+  test('should return start and end dates with timestamps for today range', () => {
+    const result = dateHelpers['today']();
+    const formattedResult = [result[0].format(), result[1].format()];
+
+    expect(formattedResult).toEqual([
+      '2019-09-13T00:00:00Z',
+      '2019-09-13T23:59:59Z'
+    ]);
+  });
+
+  test('should return start and end dates with timestamps for yesterday range', () => {
+    const result = dateHelpers['yesterday']();
+    const formattedResult = [result[0].format(), result[1].format()];
+
+    expect(formattedResult).toEqual([
+      '2019-09-12T00:00:00Z',
+      '2019-09-12T23:59:59Z'
+    ]);
+  });
+
+  afterAll(() => momentMock.mockRestore());
+});
+
+describe('Custom Range', () => {
+  test('should return start and end dates with timestamps', () => {
+    const startDate = '2019-01-01';
+    const endDate = '2019-04-01';
+    const result = dateHelpers['custom'](startDate, endDate);
+
+    const formattedResult = [result[0].format(), result[1].format()];
+
+    expect(formattedResult).toEqual([
+      '2019-01-01T00:00:00Z',
+      '2019-04-01T23:59:59Z'
+    ]);
+  });
+});


### PR DESCRIPTION
## Brief context on code (tell us why these changes are necessary)
Date helpers were not including the timestamps on the results, only the day. This helps with more granular reporting and helps other teams needs. 

![](https://media1.tenor.com/images/a1f27eaff362a3e31f37329e5efc60d7/tenor.gif?itemid=7964670)

## Test plan
New tests have been added, everything else should function as it did before.

## Before asking for code review

- [x] I have unit tested behavioral changes
- [x] I have verified test plan works
- [x] I have merged the base branch into this branch
- [x] I have ensured that CI is passing
- [x] I have filled out the "Brief context on code" and "Test plan" sections above
- [x] I have updated the version in package.json
