### PR TITLE
make last 12 months in dateHelpers to the date 

### DIFF
--- a/build/Charts/utils/dateHelpers.js
+++ b/build/Charts/utils/dateHelpers.js
@@ -34,7 +34,7 @@ var lastYear = function lastYear() {
 };
 
 var last12Months = function last12Months() {
-  return [moment.utc().subtract(12, 'month').startOf('month'), moment.utc().startOf('month')];
+  return [moment.utc().subtract(12, 'month'), moment.utc()];
 }; // Add timestamps to dates
 
 

--- a/build/Charts/utils/dateHelpers.js
+++ b/build/Charts/utils/dateHelpers.js
@@ -34,7 +34,7 @@ var lastYear = function lastYear() {
 };
 
 var last12Months = function last12Months() {
-  return [moment.utc().subtract(12, 'month'), moment.utc()];
+  return [moment.utc().subtract(12, 'month').startOf('day'), moment.utc()];
 }; // Add timestamps to dates
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podium-reporting-toolkit",
-  "version": "0.16.8",
+  "version": "0.16.9",
   "description": "A collection of Podium's reporting platform and charting components built in React.",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/src/Charts/utils/dateHelpers.js
+++ b/src/Charts/utils/dateHelpers.js
@@ -62,13 +62,7 @@ const lastYear = () => [
     .endOf('year')
 ];
 
-const last12Months = () => [
-  moment
-    .utc()
-    .subtract(12, 'month')
-    .startOf('month'),
-  moment.utc().startOf('month')
-];
+const last12Months = () => [moment.utc().subtract(12, 'month'), moment.utc()];
 
 // Add timestamps to dates
 const custom = (startDate, endDate) => [

--- a/src/Charts/utils/dateHelpers.js
+++ b/src/Charts/utils/dateHelpers.js
@@ -62,7 +62,13 @@ const lastYear = () => [
     .endOf('year')
 ];
 
-const last12Months = () => [moment.utc().subtract(12, 'month'), moment.utc()];
+const last12Months = () => [
+  moment
+    .utc()
+    .subtract(12, 'month')
+    .startOf('day'),
+  moment.utc()
+];
 
 // Add timestamps to dates
 const custom = (startDate, endDate) => [

--- a/src/__tests__/chartHelpers.test.js
+++ b/src/__tests__/chartHelpers.test.js
@@ -63,7 +63,7 @@ describe('chartHelpers', () => {
 
       it('should calculate correct date range for last12Months', () => {
         const result = renderRangeLabel('last12Months');
-        expect(result).toEqual('September 1, 2018 - September 1, 2019');
+        expect(result).toEqual('September 13, 2018 - September 13, 2019');
       });
 
       it('should calculate correct date range for lastYear', () => {


### PR DESCRIPTION
## Brief context on code (tell us why these changes are necessary)
This updates the `last12Months` date helper to return the last 12 months to the current date (instead of rounding to the beginning of the month).

## Test plan
QA in storybook

## Before asking for code review

- [x] I have unit tested behavioral changes
- [x] I have verified test plan works
- [x] I have merged the base branch into this branch
- [x] I have ensured that CI is passing
- [x] I have filled out the "Brief context on code" and "Test plan" sections above
- [ ] I have updated the version in package.json
