### PR TITLE
Bring back weekly granularity

### DIFF
--- a/build/Charts/Granularity.js
+++ b/build/Charts/Granularity.js
@@ -37,9 +37,11 @@ var GranularityWrapper = styled.div(_templateObject(), colors.mystic);
 var byMonth = {
   value: 'month',
   label: 'By Month'
-}; // TODO: add back after we resolve issues related to weekly granularity in the platform
-// const byWeek = { value: 'week', label: 'By Week' };
-
+};
+var byWeek = {
+  value: 'week',
+  label: 'By Week'
+};
 var byDay = {
   value: 'day',
   label: 'By Day'
@@ -52,14 +54,14 @@ var optionsMap = {
   gtNinetyDays: [byMonth],
   gtThirtyOneDays: [byMonth, byDay],
   ltThirtyOneDays: [byDay],
-  lastMonth: [byDay],
-  last12Months: [byMonth],
+  lastMonth: [byWeek, byDay],
+  last12Months: [byMonth, byWeek],
   lastWeek: [byDay, byHour],
-  lastYear: [byMonth],
-  monthToDate: [byDay],
+  lastYear: [byMonth, byWeek],
+  monthToDate: [byWeek, byDay],
   today: [byHour],
   weekToDate: [byDay, byHour],
-  yearToDate: [byMonth],
+  yearToDate: [byMonth, byWeek],
   yesterday: [byHour]
 };
 export var getOptions = function getOptions(timeRange) {

--- a/build/Charts/Granularity.js
+++ b/build/Charts/Granularity.js
@@ -51,8 +51,8 @@ var byHour = {
   label: 'By Hour'
 };
 var optionsMap = {
-  gtNinetyDays: [byMonth],
-  gtThirtyOneDays: [byMonth, byDay],
+  gtNinetyDays: [byMonth, byWeek],
+  gtThirtyOneDays: [byMonth, byWeek, byDay],
   ltThirtyOneDays: [byDay],
   lastMonth: [byWeek, byDay],
   last12Months: [byMonth, byWeek],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podium-reporting-toolkit",
-  "version": "0.16.9",
+  "version": "0.16.10",
   "description": "A collection of Podium's reporting platform and charting components built in React.",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/src/Charts/Granularity.jsx
+++ b/src/Charts/Granularity.jsx
@@ -22,8 +22,8 @@ const byDay = { value: 'day', label: 'By Day' };
 const byHour = { value: 'hour', label: 'By Hour' };
 
 const optionsMap = {
-  gtNinetyDays: [byMonth],
-  gtThirtyOneDays: [byMonth, byDay],
+  gtNinetyDays: [byMonth, byWeek],
+  gtThirtyOneDays: [byMonth, byWeek, byDay],
   ltThirtyOneDays: [byDay],
   lastMonth: [byWeek, byDay],
   last12Months: [byMonth, byWeek],

--- a/src/Charts/Granularity.jsx
+++ b/src/Charts/Granularity.jsx
@@ -17,8 +17,7 @@ const GranularityWrapper = styled.div`
 `;
 
 const byMonth = { value: 'month', label: 'By Month' };
-// TODO: add back after we resolve issues related to weekly granularity in the platform
-// const byWeek = { value: 'week', label: 'By Week' };
+const byWeek = { value: 'week', label: 'By Week' };
 const byDay = { value: 'day', label: 'By Day' };
 const byHour = { value: 'hour', label: 'By Hour' };
 
@@ -26,14 +25,14 @@ const optionsMap = {
   gtNinetyDays: [byMonth],
   gtThirtyOneDays: [byMonth, byDay],
   ltThirtyOneDays: [byDay],
-  lastMonth: [byDay],
-  last12Months: [byMonth],
+  lastMonth: [byWeek, byDay],
+  last12Months: [byMonth, byWeek],
   lastWeek: [byDay, byHour],
-  lastYear: [byMonth],
-  monthToDate: [byDay],
+  lastYear: [byMonth, byWeek],
+  monthToDate: [byWeek, byDay],
   today: [byHour],
   weekToDate: [byDay, byHour],
-  yearToDate: [byMonth],
+  yearToDate: [byMonth, byWeek],
   yesterday: [byHour]
 };
 

--- a/src/__tests__/Granularity.test.js
+++ b/src/__tests__/Granularity.test.js
@@ -46,8 +46,8 @@ describe('Granularity', () => {
       );
 
       expect(days15Options).toEqual([byDay]);
-      expect(days45Options).toEqual([byMonth, byDay]);
-      expect(days91Options).toEqual([byMonth]);
+      expect(days45Options).toEqual([byMonth, byWeek, byDay]);
+      expect(days91Options).toEqual([byMonth, byWeek]);
     });
 
     it('should exclude options provided in the exclude param', () => {

--- a/src/__tests__/Granularity.test.js
+++ b/src/__tests__/Granularity.test.js
@@ -1,7 +1,7 @@
 import { getOptions } from '../Charts/Granularity';
 
 const byMonth = { value: 'month', label: 'By Month' };
-// const byWeek = { value: 'week', label: 'By Week' };
+const byWeek = { value: 'week', label: 'By Week' };
 const byDay = { value: 'day', label: 'By Day' };
 const byHour = { value: 'hour', label: 'By Hour' };
 
@@ -16,8 +16,8 @@ describe('Granularity', () => {
       const lastMonthOptions = getOptions(lastMonth);
       const lastWeekOptions = getOptions(lastWeek);
 
-      expect(lastYearOptions).toEqual([byMonth]);
-      expect(lastMonthOptions).toEqual([byDay]);
+      expect(lastYearOptions).toEqual([byMonth, byWeek]);
+      expect(lastMonthOptions).toEqual([byWeek, byDay]);
       expect(lastWeekOptions).toEqual([byDay, byHour]);
     });
 


### PR DESCRIPTION
## Brief context on code (tell us why these changes are necessary)

We previously removed weekly granularity as an option, due to problems and inconsistencies with how we fetched it. But these have been resolved in Snowden and Magic. Now we are ready to bring the weekly granularity option back.

This is essentially a revert of #67.

## Test plan

Pull in the build to Kazaam and click around in the charts. Make sure weekly granularity returns data that includes days outside the month in order to go from weekend to weekend.

Make sure to especially check:

- Last month
- Last year
- Last 12 months
- Month to date
- Year to date

## Before asking for code review

- [x] I have unit tested behavioral changes
- [x] I have verified test plan works
- [x] I have merged the base branch into this branch
- [x] I have ensured that CI is passing
- [x] I have filled out the "Brief context on code" and "Test plan" sections above
- [x] I have updated the version in package.json
