### PR TITLE
Grey line chart tooltips

### DIFF
--- a/build/Charts/Chart.js
+++ b/build/Charts/Chart.js
@@ -1,7 +1,3 @@
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
 function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
@@ -33,7 +29,7 @@ import { colors } from '@podiumhq/podium-ui';
 import { ResponsiveContainer, Bar as RechartsBar, CartesianGrid as RechartsCartesianGrid, Line as RechartsLine, Tooltip as RechartsTooltip, XAxis as RechartsXAxis, YAxis as RechartsYAxis, Dot as RechartsDot } from 'recharts';
 import Rectangle from './Rectangle';
 import { ChartWrapper } from './ChartStyledComponents';
-import { detectChartType, getStackPositions, singleLineChart, filterChildren, getDeselectedColor } from './utils/chartHelpers';
+import { detectChartType, getStackPositions, filterChildren, getDeselectedColor } from './utils/chartHelpers';
 import { XAxis, YAxis, Bar, Line, SummaryLine, Tooltip } from './skeletonComponents';
 import GhostChart from './Ghost/GhostChart';
 import ReportCardContext from './ReportCardContext';
@@ -255,21 +251,11 @@ var _initialiseProps = function _initialiseProps() {
   };
 
   this.renderTooltip = function (props) {
-    var filteredChildren = filterChildren(_this3.props.children);
-    var singleLine = singleLineChart(filteredChildren);
-    var cursorSettings = {
-      fill: '#F1F2F4',
-      strokeWidth: 1
-    };
-
-    if (singleLine) {
-      cursorSettings = _objectSpread({}, cursorSettings, {
-        stroke: singleLine.color
-      });
-    }
-
     return React.createElement(RechartsTooltip, _extends({
-      cursor: cursorSettings,
+      cursor: {
+        fill: '#F1F2F4',
+        strokeWidth: 1
+      },
       isAnimationActive: false,
       offset: 20,
       wrapperStyle: {

--- a/build/Charts/utils/chartHelpers.js
+++ b/build/Charts/utils/chartHelpers.js
@@ -49,17 +49,6 @@ export function getStackPositions(children) {
   });
   return groupBy(stackPosition, 'stackId');
 }
-export function singleLineChart(children) {
-  var filteredChildren = filterChildren(children);
-  var graphElements = new Set([Line, Bar]);
-  var numberOfLines = 0;
-  var lineProps = {};
-  React.Children.forEach(filteredChildren, function (child) {
-    if (child.type === Line) lineProps = child.props;
-    if (graphElements.has(child.type)) numberOfLines += 1;
-  });
-  return numberOfLines === 1 ? lineProps : false;
-}
 export var filterChildren = function filterChildren(children) {
   return React.Children.toArray(children).filter(function (child) {
     return child;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podium-reporting-toolkit",
-  "version": "0.16.10",
+  "version": "0.16.11",
   "description": "A collection of Podium's reporting platform and charting components built in React.",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/src/Charts/Chart.jsx
+++ b/src/Charts/Chart.jsx
@@ -17,7 +17,6 @@ import { ChartWrapper } from './ChartStyledComponents';
 import {
   detectChartType,
   getStackPositions,
-  singleLineChart,
   filterChildren,
   getDeselectedColor
 } from './utils/chartHelpers';
@@ -187,18 +186,9 @@ export default class Chart extends React.Component {
   );
 
   renderTooltip = props => {
-    const filteredChildren = filterChildren(this.props.children);
-    const singleLine = singleLineChart(filteredChildren);
-    let cursorSettings = { fill: '#F1F2F4', strokeWidth: 1 };
-    if (singleLine) {
-      cursorSettings = {
-        ...cursorSettings,
-        stroke: singleLine.color
-      };
-    }
     return (
       <RechartsTooltip
-        cursor={cursorSettings}
+        cursor={{ fill: '#F1F2F4', strokeWidth: 1 }}
         isAnimationActive={false}
         offset={20}
         wrapperStyle={{

--- a/src/Charts/utils/chartHelpers.js
+++ b/src/Charts/utils/chartHelpers.js
@@ -43,18 +43,6 @@ export function getStackPositions(children) {
   return groupBy(stackPosition, 'stackId');
 }
 
-export function singleLineChart(children) {
-  const filteredChildren = filterChildren(children);
-  const graphElements = new Set([Line, Bar]);
-  let numberOfLines = 0;
-  let lineProps = {};
-  React.Children.forEach(filteredChildren, child => {
-    if (child.type === Line) lineProps = child.props;
-    if (graphElements.has(child.type)) numberOfLines += 1;
-  });
-  return numberOfLines === 1 ? lineProps : false;
-}
-
 export const filterChildren = children => {
   return React.Children.toArray(children).filter(child => child);
 };


### PR DESCRIPTION
## Brief context on code (tell us why these changes are necessary)

This changes tooltips for line charts, so that the tooltip line is always grey, whether there is a single series of data or multiple series.

## Test plan

- Run stories, go to a story with a line chart and a tooltip (For example: `Report Card > w/Tooltip`).
- Hover over the data in the chart. Make sure the line is grey.
- Edit the source for the story and delete all the series but one. Hover again and make sure the line is still grey.

## Before asking for code review

- [ ] I have unit tested behavioral changes
- [x] I have verified test plan works
- [x] I have merged the base branch into this branch
- [x] I have ensured that CI is passing
- [x] I have filled out the "Brief context on code" and "Test plan" sections above
- [x] I have updated the version in package.json
