### PR TITLE
tooltip now accounts for granularity, and correctly shows week range

### DIFF
--- a/build/Charts/TooltipBody.js
+++ b/build/Charts/TooltipBody.js
@@ -117,15 +117,18 @@ var granMap = {
 };
 
 var fullDate = function fullDate(date, granularity) {
+  var momentDate = moment.utc(date);
+  if (!momentDate.isValid()) return date;
+
   if (granularity === 'week') {
-    var formattedDateRange = "".concat(moment.utc(date).startOf('week').format('MMM D'), " - ").concat(moment.utc(date).endOf('week').format('MMM D, YYYY'));
+    var startDate = momentDate.startOf('week').format('MMM D');
+    var endDate = momentDate.endOf('week').format('MMM D, YYYY');
+    var formattedDateRange = "".concat(startDate, " - ").concat(endDate);
     return formattedDateRange;
   }
 
   var format = granMap[granularity] || 'MMMM YYYY';
-  var momentDate = moment.utc(date);
-  if (momentDate.isValid()) return momentDate.format(format);
-  return date;
+  return momentDate.format(format);
 };
 
 export default function TooltipBody(props) {

--- a/build/Charts/TooltipBody.js
+++ b/build/Charts/TooltipBody.js
@@ -121,10 +121,9 @@ var fullDate = function fullDate(date, granularity) {
   if (!momentDate.isValid()) return date;
 
   if (granularity === 'week') {
-    var startDate = momentDate.startOf('week').format('MMM D');
-    var endDate = momentDate.endOf('week').format('MMM D, YYYY');
-    var formattedDateRange = "".concat(startDate, " - ").concat(endDate);
-    return formattedDateRange;
+    var startDate = momentDate.clone().startOf('week').format('MMM D');
+    var endDate = momentDate.clone().endOf('week').format('MMM D, YYYY');
+    return "".concat(startDate, " - ").concat(endDate);
   }
 
   var format = granMap[granularity] || 'MMMM YYYY';

--- a/build/Charts/TooltipBody.js
+++ b/build/Charts/TooltipBody.js
@@ -113,7 +113,8 @@ var granMap = {
   month: 'MMMM YYYY',
   year: 'YYYY',
   day: 'MMMM D, YYYY',
-  week: 'MMMM D, YYYY'
+  week: 'MMMM D, YYYY',
+  hour: 'h:mm A MMM D, YYYY'
 };
 
 var fullDate = function fullDate(date, granularity) {

--- a/build/Charts/TooltipBody.js
+++ b/build/Charts/TooltipBody.js
@@ -117,6 +117,11 @@ var granMap = {
 };
 
 var fullDate = function fullDate(date, granularity) {
+  if (granularity === 'week') {
+    var formattedDateRange = "".concat(moment.utc(date).startOf('week').format('MMM D'), " - ").concat(moment.utc(date).endOf('week').format('MMM D, YYYY'));
+    return formattedDateRange;
+  }
+
   var format = granMap[granularity] || 'MMMM YYYY';
   var momentDate = moment.utc(date);
   if (momentDate.isValid()) return momentDate.format(format);
@@ -124,6 +129,8 @@ var fullDate = function fullDate(date, granularity) {
 };
 
 export default function TooltipBody(props) {
+  var granularity = props.granularity;
+
   var renderSummary = function renderSummary() {
     var payload = props.payload,
         summaryTitle = props.summaryTitle,
@@ -158,7 +165,7 @@ export default function TooltipBody(props) {
   };
 
   var summary = renderSummary();
-  return React.createElement(TooltipBodyWrapper, null, React.createElement(Header, null, React.createElement(XAxisLabel, null, fullDate(props.label)), summary && React.createElement(Summary, null, summary)), props.showLegend && props.payload && React.createElement(Body, null, renderToolTipLegend()));
+  return React.createElement(TooltipBodyWrapper, null, React.createElement(Header, null, React.createElement(XAxisLabel, null, fullDate(props.label, granularity)), summary && React.createElement(Summary, null, summary)), props.showLegend && props.payload && React.createElement(Body, null, renderToolTipLegend()));
 }
 TooltipBody.propTypes = {
   aggregationOptions: PropTypes.shape({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podium-reporting-toolkit",
-  "version": "0.16.11",
+  "version": "0.16.12",
   "description": "A collection of Podium's reporting platform and charting components built in React.",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/src/Charts/TooltipBody.jsx
+++ b/src/Charts/TooltipBody.jsx
@@ -65,7 +65,8 @@ const granMap = {
   month: 'MMMM YYYY',
   year: 'YYYY',
   day: 'MMMM D, YYYY',
-  week: 'MMMM D, YYYY'
+  week: 'MMMM D, YYYY',
+  hour: 'h:mm A MMM D, YYYY'
 };
 
 const fullDate = (date, granularity) => {

--- a/src/Charts/TooltipBody.jsx
+++ b/src/Charts/TooltipBody.jsx
@@ -69,20 +69,18 @@ const granMap = {
 };
 
 const fullDate = (date, granularity) => {
+  const momentDate = moment.utc(date);
+  if (!momentDate.isValid()) return date;
+
   if (granularity === 'week') {
-    let formattedDateRange = `${moment
-      .utc(date)
-      .startOf('week')
-      .format('MMM D')} - ${moment
-      .utc(date)
-      .endOf('week')
-      .format('MMM D, YYYY')}`;
+    const startDate = momentDate.startOf('week').format('MMM D');
+    const endDate = momentDate.endOf('week').format('MMM D, YYYY');
+    const formattedDateRange = `${startDate} - ${endDate}`;
     return formattedDateRange;
   }
+
   const format = granMap[granularity] || 'MMMM YYYY';
-  const momentDate = moment.utc(date);
-  if (momentDate.isValid()) return momentDate.format(format);
-  return date;
+  return momentDate.format(format);
 };
 
 export default function TooltipBody(props) {

--- a/src/Charts/TooltipBody.jsx
+++ b/src/Charts/TooltipBody.jsx
@@ -73,10 +73,15 @@ const fullDate = (date, granularity) => {
   if (!momentDate.isValid()) return date;
 
   if (granularity === 'week') {
-    const startDate = momentDate.startOf('week').format('MMM D');
-    const endDate = momentDate.endOf('week').format('MMM D, YYYY');
-    const formattedDateRange = `${startDate} - ${endDate}`;
-    return formattedDateRange;
+    const startDate = momentDate
+      .clone()
+      .startOf('week')
+      .format('MMM D');
+    const endDate = momentDate
+      .clone()
+      .endOf('week')
+      .format('MMM D, YYYY');
+    return `${startDate} - ${endDate}`;
   }
 
   const format = granMap[granularity] || 'MMMM YYYY';

--- a/src/Charts/TooltipBody.jsx
+++ b/src/Charts/TooltipBody.jsx
@@ -69,6 +69,16 @@ const granMap = {
 };
 
 const fullDate = (date, granularity) => {
+  if (granularity === 'week') {
+    let formattedDateRange = `${moment
+      .utc(date)
+      .startOf('week')
+      .format('MMM D')} - ${moment
+      .utc(date)
+      .endOf('week')
+      .format('MMM D, YYYY')}`;
+    return formattedDateRange;
+  }
   const format = granMap[granularity] || 'MMMM YYYY';
   const momentDate = moment.utc(date);
   if (momentDate.isValid()) return momentDate.format(format);
@@ -76,6 +86,7 @@ const fullDate = (date, granularity) => {
 };
 
 export default function TooltipBody(props) {
+  const { granularity } = props;
   const renderSummary = () => {
     const { payload, summaryTitle, aggregationOptions, formatter } = props;
     let result = null;
@@ -114,7 +125,7 @@ export default function TooltipBody(props) {
   return (
     <TooltipBodyWrapper>
       <Header>
-        <XAxisLabel>{fullDate(props.label)}</XAxisLabel>
+        <XAxisLabel>{fullDate(props.label, granularity)}</XAxisLabel>
         {summary && <Summary>{summary}</Summary>}
       </Header>
       {props.showLegend && props.payload && (


### PR DESCRIPTION
## Brief context on code (tell us why these changes are necessary)
Tooltip was always showing the date formatted as `MMMM YYYY` regardless of granularity selected. This now accounts for granularity and displays different date/date range formats according to the selected granularity.
## Test plan
Pass different granularities down as props through `<TooltipBody />` and ensure the tooltip displays the expected formats. 
## Before asking for code review

- [ ] I have unit tested behavioral changes
- [x] I have verified test plan works
- [x] I have merged the base branch into this branch
- [ ] I have ensured that CI is passing
- [x] I have filled out the "Brief context on code" and "Test plan" sections above
- [x] I have updated the version in package.json
