### PR TITLE
added a key to Dots rendered in a Summaryline so we don't get console…

### DIFF
--- a/build/Charts/Chart.js
+++ b/build/Charts/Chart.js
@@ -235,6 +235,7 @@ var _initialiseProps = function _initialiseProps() {
       dot: function dot(data) {
         if (data.index === _this3.props.data.length - 1) {
           return React.createElement(RechartsDot, {
+            key: data.key,
             r: 2.5,
             cx: data.cx,
             cy: data.cy,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podium-reporting-toolkit",
-  "version": "0.16.15",
+  "version": "0.16.16",
   "description": "A collection of Podium's reporting platform and charting components built in React.",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/src/Charts/Chart.jsx
+++ b/src/Charts/Chart.jsx
@@ -169,6 +169,7 @@ export default class Chart extends React.Component {
         if (data.index === this.props.data.length - 1) {
           return (
             <RechartsDot
+              key={data.key}
               r={2.5}
               cx={data.cx}
               cy={data.cy}


### PR DESCRIPTION
## Brief context on code (tell us why these changes are necessary)

The SummaryLine chart was creating unique key errors in the console. This is a small tweak to ensure that the key gets passed to the Dots.

## Test plan

Run kazaam with the updated library. Go to the Dashboard page and make sure there isn't a unique key warning in the console.

## Before asking for code review

- [x] I have unit tested behavioral changes
- [x] I have verified test plan works
- [x] I have merged the base branch into this branch
- [ ] I have ensured that CI is passing
- [x] I have filled out the "Brief context on code" and "Test plan" sections above
- [x] I have updated the version in package.json
