### PR TITLE
Dallinskinner/report card loading prop

### DIFF
--- a/build/Charts/ReportCard.js
+++ b/build/Charts/ReportCard.js
@@ -156,13 +156,20 @@ function (_React$Component) {
               loading: loading
             });
           } else if (child.props.children) {
+            var subChildren = [];
+            var type;
             React.Children.forEach(child.props.children, function (subChild) {
               if (componentKeyMap.has(subChild.type)) {
-                newComponents[componentKeyMap.get(subChild.type)] = React.cloneElement(child, {
+                subChildren.push(React.cloneElement(subChild, {
                   loading: loading
-                });
+                }));
+                type = componentKeyMap.get(subChild.type);
               }
             });
+
+            if (type) {
+              newComponents[type] = React.cloneElement.apply(React, [child, {}].concat(subChildren));
+            }
           }
         });
         return newComponents;

--- a/build/Charts/ReportTitle.js
+++ b/build/Charts/ReportTitle.js
@@ -58,7 +58,7 @@ export default function ReportTitle(_ref) {
   return React.createElement(TitleWrapper, null, React.createElement(Title, null, title), React.createElement(RangeLabel, null, loading ? React.createElement(DateRangePlaceholder, null, "Date Range") : renderRangeLabel(timeRange, dateStart, dateEnd)));
 }
 ReportTitle.propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.node.isRequired,
   timeRange: PropTypes.string,
   dateStart: PropTypes.string,
   dateEnd: PropTypes.string,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podium-reporting-toolkit",
-  "version": "0.16.16",
+  "version": "0.16.17",
   "description": "A collection of Podium's reporting platform and charting components built in React.",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@babel/core": "^7.1.6",
     "@babel/preset-env": "^7.2.0",
     "@babel/preset-react": "^7.0.0",
-    "@podiumhq/podium-ui": "^16.3.2",
+    "@podiumhq/podium-ui": "^16.15.0",
     "@storybook/addon-actions": "^5.0.5",
     "@storybook/addon-console": "^1.1.0",
     "@storybook/addon-info": "^5.0.5",

--- a/src/Charts/ReportCard.jsx
+++ b/src/Charts/ReportCard.jsx
@@ -97,13 +97,19 @@ export default class ReportCard extends React.Component {
             { loading: loading }
           );
         } else if (child.props.children) {
+          const subChildren = [];
+          let type;
           React.Children.forEach(child.props.children, subChild => {
             if (componentKeyMap.has(subChild.type)) {
-              newComponents[
-                componentKeyMap.get(subChild.type)
-              ] = React.cloneElement(child, { loading: loading });
+              subChildren.push(
+                React.cloneElement(subChild, { loading: loading })
+              );
+              type = componentKeyMap.get(subChild.type);
             }
           });
+          if (type) {
+            newComponents[type] = React.cloneElement(child, {}, ...subChildren);
+          }
         }
       });
 

--- a/src/Charts/ReportTitle.jsx
+++ b/src/Charts/ReportTitle.jsx
@@ -47,7 +47,7 @@ export default function ReportTitle({
 }
 
 ReportTitle.propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.node.isRequired,
   timeRange: PropTypes.string,
   dateStart: PropTypes.string,
   dateEnd: PropTypes.string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1112,10 +1112,10 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@podiumhq/podium-ui@^16.3.2":
-  version "16.3.2"
-  resolved "https://registry.yarnpkg.com/@podiumhq/podium-ui/-/podium-ui-16.3.2.tgz#d02ed89f8556d95bbcedce6d49fa25b0e159b5be"
-  integrity sha512-fcRYmLYlmLniI+/ap/Al2ZxCU6TL+Q9Y5EE6DBVXPtVEaiOVEKE9HO/lOjTQhSgvnMQ9if5OOHVhBAqonjwokw==
+"@podiumhq/podium-ui@^16.15.0":
+  version "16.15.0"
+  resolved "https://registry.yarnpkg.com/@podiumhq/podium-ui/-/podium-ui-16.15.0.tgz#057db3bce51f525d15ad2772983f0fb9283f8f82"
+  integrity sha512-jQwFahHitiiLBh/S5mI0ZHnuafL6fxye4P4IaDWm3q9vO575G/M4nwvKpouiGrGdW4Ju0NvMdwp2A6lPrTyKCQ==
   dependencies:
     dayjs "1.7.8"
     fuse.js "3.4.2"
@@ -1123,7 +1123,6 @@
     moment "^2.17.1"
     polished "^2.3.3"
     prop-types "^15.5.10"
-    pure-render-decorator "^1.2.1"
     react-datepicker "^1.8.0"
     react-modal "^3.1.11"
     react-onclickoutside "^6.1.1"
@@ -9161,13 +9160,6 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-
-pure-render-decorator@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/pure-render-decorator/-/pure-render-decorator-1.2.1.tgz#568870eeca17a1cee536b4fe94a3477fcd31eeb9"
-  integrity sha1-Vohw7soXoc7lNrT+lKNHf80x7rk=
-  dependencies:
-    fbjs "^0.8.0"
 
 q@^1.1.2:
   version "1.5.1"


### PR DESCRIPTION
## Brief context on code (tell us why these changes are necessary)

ReportTitle was expecting the `title` prop to be a string but were were also passing React elements to it. Changed the propType from string to node.

The ReportCard component was passing the loading prop to wrapping divs instead of the components they were intended for. This made some of the components not respond to the loading prop as well as throw an error for passing a boolean prop to a div.

An old version of podium-ui was in the dev dependencies so it was logging an error about the onClickOutside prop.

## Test plan

1. Load kazaam, go to Dashboard and click Inbound Leads, check the console and see that there are no errors.
2. Go to React dev tools and search for ReportCard. Toggle the loading prop to true and make sure the chart and title show a ghost state.

## Before asking for code review

- [x] I have unit tested behavioral changes
- [x] I have verified test plan works
- [x] I have merged the base branch into this branch
- [ ] I have ensured that CI is passing
- [x] I have filled out the "Brief context on code" and "Test plan" sections above
- [x] I have updated the version in package.json
