### PR TITLE
added placeholder elements and min-width to avoid jumpiness

### DIFF
--- a/build/Pagination/Pagination.js
+++ b/build/Pagination/Pagination.js
@@ -1,5 +1,25 @@
-function _templateObject4() {
+function _templateObject6() {
   var data = _taggedTemplateLiteral(["\n  margin: 0 2px;\n"]);
+
+  _templateObject6 = function _templateObject6() {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject5() {
+  var data = _taggedTemplateLiteral(["\n  margin: 0 2px;\n"]);
+
+  _templateObject5 = function _templateObject5() {
+    return data;
+  };
+
+  return data;
+}
+
+function _templateObject4() {
+  var data = _taggedTemplateLiteral(["\n  min-width: 120px;\n  display: flex;\n  justify-content: center;\n"]);
 
   _templateObject4 = function _templateObject4() {
     return data;
@@ -9,7 +29,7 @@ function _templateObject4() {
 }
 
 function _templateObject3() {
-  var data = _taggedTemplateLiteral(["\n  margin: 0 2px;\n"]);
+  var data = _taggedTemplateLiteral(["\n  min-width: 65px;\n  margin: 0 4px;\n"]);
 
   _templateObject3 = function _templateObject3() {
     return data;
@@ -19,7 +39,7 @@ function _templateObject3() {
 }
 
 function _templateObject2() {
-  var data = _taggedTemplateLiteral(["\n  color: ", ";\n  cursor: pointer;\n  margin: 0 2px;\n"]);
+  var data = _taggedTemplateLiteral(["\n  color: ", ";\n  cursor: pointer;\n  margin: 0 4px;\n  min-width: 65px;\n"]);
 
   _templateObject2 = function _templateObject2() {
     return data;
@@ -46,22 +66,24 @@ import { colors } from '@podiumhq/podium-ui';
 import PropTypes from 'prop-types';
 var Container = styled.div(_templateObject());
 var ChangeLink = styled.div(_templateObject2(), colors.cobaltBlue);
-var Label = styled.div(_templateObject3());
-var Page = styled.div(_templateObject4());
+var Placeholder = styled.div(_templateObject3());
+var PageCountWrapper = styled.div(_templateObject4());
+var Label = styled.div(_templateObject5());
+var Page = styled.div(_templateObject6());
 
 var Pagination = function Pagination(_ref) {
   var currentPage = _ref.currentPage,
       totalPages = _ref.totalPages,
       onPageChange = _ref.onPageChange;
-  return React.createElement(Container, null, currentPage > 1 && React.createElement(ChangeLink, {
+  return React.createElement(Container, null, currentPage > 1 ? React.createElement(ChangeLink, {
     onClick: function onClick() {
       return onPageChange(currentPage - 1);
     }
-  }, "Previous"), React.createElement(Label, null, "Page"), React.createElement(Page, null, currentPage, " /"), React.createElement(Page, null, totalPages), currentPage < totalPages && React.createElement(ChangeLink, {
+  }, "Previous") : React.createElement(Placeholder, null), React.createElement(PageCountWrapper, null, React.createElement(Label, null, "Page"), React.createElement(Page, null, currentPage, " /"), React.createElement(Page, null, totalPages)), currentPage < totalPages ? React.createElement(ChangeLink, {
     onClick: function onClick() {
       return onPageChange(currentPage + 1);
     }
-  }, "Next"));
+  }, "Next") : React.createElement(Placeholder, null));
 };
 
 Pagination.propTypes = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podium-reporting-toolkit",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "A collection of Podium's reporting platform and charting components built in React.",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/src/Pagination/Pagination.jsx
+++ b/src/Pagination/Pagination.jsx
@@ -11,7 +11,18 @@ const Container = styled.div`
 const ChangeLink = styled.div`
   color: ${colors.cobaltBlue};
   cursor: pointer;
-  margin: 0 2px;
+  margin: 0 4px;
+  min-width: 65px;
+`;
+
+const Placeholder = styled.div`
+  min-width: 65px;
+  margin: 0 4px;
+`;
+const PageCountWrapper = styled.div`
+  min-width: 120px;
+  display: flex;
+  justify-content: center;
 `;
 
 const Label = styled.div`
@@ -25,18 +36,24 @@ const Page = styled.div`
 const Pagination = ({ currentPage, totalPages, onPageChange }) => {
   return (
     <Container>
-      {currentPage > 1 && (
+      {currentPage > 1 ? (
         <ChangeLink onClick={() => onPageChange(currentPage - 1)}>
           Previous
         </ChangeLink>
+      ) : (
+        <Placeholder />
       )}
-      <Label>Page</Label>
-      <Page>{currentPage} /</Page>
-      <Page>{totalPages}</Page>
-      {currentPage < totalPages && (
+      <PageCountWrapper>
+        <Label>Page</Label>
+        <Page>{currentPage} /</Page>
+        <Page>{totalPages}</Page>
+      </PageCountWrapper>
+      {currentPage < totalPages ? (
         <ChangeLink onClick={() => onPageChange(currentPage + 1)}>
           Next
         </ChangeLink>
+      ) : (
+        <Placeholder />
       )}
     </Container>
   );


### PR DESCRIPTION
## Brief context on code (tell us why these changes are necessary)
When on page 1 or the last page, the previous and next buttons would disappear and cause the spacing to jump fairly drastically. As page numbers changed, the slight size difference also caused some jump as well. By adding placeholders and min-widths, this jumpiness has been removed. 
## Test plan
Tested in storybook to verify it still works as expected. 
## Before asking for code review

- [ ] I have unit tested behavioral changes
- [X] I have verified test plan works
- [X] I have merged the base branch into this branch
- [ ] I have ensured that CI is passing
- [X] I have filled out the "Brief context on code" and "Test plan" sections above
- [X] I have updated the version in package.json
