### PR TITLE
added fallback if data is undefined or null to return an empty array

### DIFF
--- a/build/Charts/utils/transformer.js
+++ b/build/Charts/utils/transformer.js
@@ -19,6 +19,7 @@ export var singleDataset = function singleDataset(data) {
 };
 export var multiDataset = function multiDataset(data) {
   var groupBy = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
+  if (!data) return [];
   var combinedData = Object.keys(data).reduce(function (outsideAcc, alias) {
     // Look at tests in src/__tests__/transformer.test.js for examples
     // There are three ways to use this transformer:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podium-reporting-toolkit",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "description": "A collection of Podium's reporting platform and charting components built in React.",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/src/Charts/utils/transformer.js
+++ b/src/Charts/utils/transformer.js
@@ -17,6 +17,7 @@ export const singleDataset = data => {
 };
 
 export const multiDataset = (data, groupBy = null) => {
+  if (!data) return [];
   const combinedData = Object.keys(data).reduce((outsideAcc, alias) => {
     // Look at tests in src/__tests__/transformer.test.js for examples
     // There are three ways to use this transformer:


### PR DESCRIPTION
## Brief context on code (tell us why these changes are necessary)
If multiDataset was passed undefined or null, the function would cause an error that breaks the page. Adding this will remove the requirement of having a fallback when used (i.e. `data = results || []`) and will return an empty array. 
## Test plan
Test that the function returns an empty array when passed undefined, null, an empty object, or an empty array (last two don't change from current behavior). Also ensure that it passes all tests for various cases in the test suite. 
## Before asking for code review

- [x] I have unit tested behavioral changes
- [x] I have verified test plan works
- [x] I have merged the base branch into this branch
- [x] I have ensured that CI is passing
- [x] I have filled out the "Brief context on code" and "Test plan" sections above
- [x] I have updated the version in package.json
