### PR TITLE
Stacked Bars and Legend now display top-to-bottom in the order data is given. 

### DIFF
--- a/build/Charts/Chart.js
+++ b/build/Charts/Chart.js
@@ -153,9 +153,11 @@ var _initialiseProps = function _initialiseProps() {
         data = _this3$props.data;
     if (!data || data.length === 0) return null;
     var filteredChildren = filterChildren(children);
-    return React.Children.map(filteredChildren, function (child) {
+    return React.Children.toArray(filteredChildren).sort(function (child1, child2) {
+      if (child1.type === Bar && child2.type === Bar) return -1;else return 0;
+    }).map(function (child) {
       var renderComponent = mapping.get(child.type);
-      if (renderComponent) return renderComponent(child.props, renderContext);
+      if (renderComponent) return renderComponent(child.props, renderContext);else return null;
     });
   };
 

--- a/build/Charts/Chart.js
+++ b/build/Charts/Chart.js
@@ -151,7 +151,10 @@ var _initialiseProps = function _initialiseProps() {
     var _this3$props = _this3.props,
         children = _this3$props.children,
         data = _this3$props.data;
-    if (!data || data.length === 0) return null;
+    if (!data || data.length === 0) return null; // The sort is necessary, because recharts reverses the order of stacked-bar graph's data.
+    // This reverses the order of the Bar components while ignoring all other components so
+    // the order matches the order of the data passed in.
+
     var filteredChildren = filterChildren(children);
     return React.Children.toArray(filteredChildren).sort(function (child1, child2) {
       if (child1.type === Bar && child2.type === Bar) return -1;else return 0;

--- a/build/Charts/Chart.js
+++ b/build/Charts/Chart.js
@@ -151,13 +151,18 @@ var _initialiseProps = function _initialiseProps() {
     var _this3$props = _this3.props,
         children = _this3$props.children,
         data = _this3$props.data;
-    if (!data || data.length === 0) return null; // The sort is necessary, because recharts reverses the order of stacked-bar graph's data.
-    // This reverses the order of the Bar components while ignoring all other components so
-    // the order matches the order of the data passed in.
-
+    if (!data || data.length === 0) return null;
     var filteredChildren = filterChildren(children);
     return React.Children.toArray(filteredChildren).sort(function (child1, child2) {
-      if (child1.type === Bar && child2.type === Bar) return -1;else return 0;
+      if (child1.type === Bar && child2.type === Bar) {
+        // These two children are both Bars, so we want to reverse them so they
+        // render top-to-bottom instead of bottom-to-top
+        return -1;
+      } else {
+        // One or both of these children is not a Bar, so we don't want to
+        // change this sorting.
+        return 0;
+      }
     }).map(function (child) {
       var renderComponent = mapping.get(child.type);
       if (renderComponent) return renderComponent(child.props, renderContext);else return null;

--- a/build/Charts/Legend.js
+++ b/build/Charts/Legend.js
@@ -109,7 +109,7 @@ export default function Legend(_ref3) {
     displayOptions.forEach(function (item) {
       item.disabled ? filteredItems.push(item) : legendItems.push(item);
     });
-    return legendItems.reverse().concat(filteredItems).slice().map(function (legendItem) {
+    return legendItems.concat(filteredItems).slice().map(function (legendItem) {
       var dataKey = legendItem.dataKey,
           color = legendItem.color,
           name = legendItem.name,

--- a/build/Charts/Rectangle.js
+++ b/build/Charts/Rectangle.js
@@ -22,7 +22,7 @@ export default function Rectangle(props) {
     return !!payload[bar.dataKey];
   });
   if (!renderedBars.length) return React.createElement(RechartsRectangle, props);
-  var isTopBar = renderedBars[renderedBars.length - 1].dataKey === dataKey;
+  var isTopBar = renderedBars[0].dataKey === dataKey;
   if (isTopBar) return React.createElement(RechartsRectangle, _extends({}, props, {
     radius: calculateRadius(width)
   }));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podium-reporting-toolkit",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "description": "A collection of Podium's reporting platform and charting components built in React.",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/src/Charts/Chart.jsx
+++ b/src/Charts/Chart.jsx
@@ -83,6 +83,9 @@ export default class Chart extends React.Component {
     const { children, data } = this.props;
     if (!data || data.length === 0) return null;
 
+    // The sort is necessary, because recharts reverses the order of stacked-bar graph's data.
+    // This reverses the order of the Bar components while ignoring all other components so
+    // the order matches the order of the data passed in.
     const filteredChildren = filterChildren(children);
     return React.Children.toArray(filteredChildren)
       .sort((child1, child2) => {

--- a/src/Charts/Chart.jsx
+++ b/src/Charts/Chart.jsx
@@ -83,14 +83,18 @@ export default class Chart extends React.Component {
     const { children, data } = this.props;
     if (!data || data.length === 0) return null;
 
-    // The sort is necessary, because recharts reverses the order of stacked-bar graph's data.
-    // This reverses the order of the Bar components while ignoring all other components so
-    // the order matches the order of the data passed in.
     const filteredChildren = filterChildren(children);
     return React.Children.toArray(filteredChildren)
       .sort((child1, child2) => {
-        if (child1.type === Bar && child2.type === Bar) return -1;
-        else return 0;
+        if (child1.type === Bar && child2.type === Bar) {
+          // These two children are both Bars, so we want to reverse them so they
+          // render top-to-bottom instead of bottom-to-top
+          return -1;
+        } else {
+          // One or both of these children is not a Bar, so we don't want to
+          // change this sorting.
+          return 0;
+        }
       })
       .map(child => {
         const renderComponent = mapping.get(child.type);

--- a/src/Charts/Chart.jsx
+++ b/src/Charts/Chart.jsx
@@ -84,10 +84,16 @@ export default class Chart extends React.Component {
     if (!data || data.length === 0) return null;
 
     const filteredChildren = filterChildren(children);
-    return React.Children.map(filteredChildren, child => {
-      const renderComponent = mapping.get(child.type);
-      if (renderComponent) return renderComponent(child.props, renderContext);
-    });
+    return React.Children.toArray(filteredChildren)
+      .sort((child1, child2) => {
+        if (child1.type === Bar && child2.type === Bar) return -1;
+        else return 0;
+      })
+      .map(child => {
+        const renderComponent = mapping.get(child.type);
+        if (renderComponent) return renderComponent(child.props, renderContext);
+        else return null;
+      });
   };
 
   renderXAxis = ({ dataKey, ...props }) => {

--- a/src/Charts/Legend.jsx
+++ b/src/Charts/Legend.jsx
@@ -90,7 +90,6 @@ export default function Legend({
     });
 
     return legendItems
-      .reverse()
       .concat(filteredItems)
       .slice()
       .map(legendItem => {

--- a/src/Charts/Rectangle.jsx
+++ b/src/Charts/Rectangle.jsx
@@ -19,7 +19,7 @@ export default function Rectangle(props) {
 
   if (!renderedBars.length) return <RechartsRectangle {...props} />;
 
-  const isTopBar = renderedBars[renderedBars.length - 1].dataKey === dataKey;
+  const isTopBar = renderedBars[0].dataKey === dataKey;
   if (isTopBar)
     return <RechartsRectangle {...props} radius={calculateRadius(width)} />;
   return <RechartsRectangle {...props} />;


### PR DESCRIPTION
## Brief context on code (tell us why these changes are necessary)
The order of the summary/legend was being reversed to match the order of stacked-bar charts, however, now that data will be coming to us for many graphs in alphabetical order, reversing them is undesired. By reversing the order of the stacked bar chart's bars, and taking the reverse out of the legend, the data will now be displayed in the order that the data was sent. 
## Test plan
Add several `<Bar name="RANDOM_NAME" stackId='1' dataKey="MATCHING_DATA_KEY" color={colors.RANDOM_PODIUM_UI_COLOR} />` to the ReportCard.story.jsx file in the `'w/Legend (stacked bars)'` story. Also add a corresponding object `{ name: 'RANDOM_NAME', dataKey: 'MATCHING_DATA_KEY', color: colors.RANDOM_PODIUM_UI_COLOR }` to the `displayOptions` array in the `<Legend />` component. 
Then check that the legend matches the order you gave the data AND the bars are stacked in that same order. Also check other graphs and ensure they look fine, and legend should be in the same order that the data was given to it. 
## Before asking for code review

- [ ] I have unit tested behavioral changes
- [x] I have verified test plan works
- [x] I have merged the base branch into this branch
- [ ] I have ensured that CI is passing
- [x] I have filled out the "Brief context on code" and "Test plan" sections above
- [x] I have updated the version in package.json
