### PR TITLE
Tooltips now reference isoWeek timeframes for week granularity

### DIFF
--- a/build/Charts/TooltipBody.js
+++ b/build/Charts/TooltipBody.js
@@ -122,8 +122,8 @@ var fullDate = function fullDate(date, granularity) {
   if (!momentDate.isValid()) return date;
 
   if (granularity === 'week') {
-    var startDate = momentDate.clone().startOf('week').format('MMM D');
-    var endDate = momentDate.clone().endOf('week').format('MMM D, YYYY');
+    var startDate = momentDate.clone().startOf('isoWeek').format('MMM D');
+    var endDate = momentDate.clone().endOf('isoWeek').format('MMM D, YYYY');
     return "".concat(startDate, " - ").concat(endDate);
   }
 

--- a/build/Charts/TooltipBodyTime.js
+++ b/build/Charts/TooltipBodyTime.js
@@ -133,8 +133,8 @@ var fullDate = function fullDate(date, granularity) {
   if (!momentDate.isValid()) return date;
 
   if (granularity === 'week') {
-    var startDate = momentDate.clone().startOf('week').format('MMM D');
-    var endDate = momentDate.clone().endOf('week').format('MMM D, YYYY');
+    var startDate = momentDate.clone().startOf('isoWeek').format('MMM D');
+    var endDate = momentDate.clone().endOf('isoWeek').format('MMM D, YYYY');
     return "".concat(startDate, " - ").concat(endDate);
   }
 

--- a/build/Charts/utils/dateHelpers.js
+++ b/build/Charts/utils/dateHelpers.js
@@ -5,7 +5,7 @@ var today = function today() {
 };
 
 var thisWeek = function thisWeek() {
-  return [moment.utc().startOf('week').add(1, 'day'), moment.utc()];
+  return [moment.utc().startOf('isoWeek'), moment.utc()];
 };
 
 var thisMonth = function thisMonth() {
@@ -22,7 +22,7 @@ var yesterday = function yesterday() {
 };
 
 var lastWeek = function lastWeek() {
-  return [moment.utc().subtract(1, 'week').startOf('week').add(1, 'day'), moment.utc().subtract(1, 'week').endOf('week').add(1, 'day')];
+  return [moment.utc().subtract(1, 'week').startOf('isoWeek'), moment.utc().subtract(1, 'week').endOf('isoWeek')];
 };
 
 var lastMonth = function lastMonth() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podium-reporting-toolkit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A collection of Podium's reporting platform and charting components built in React.",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/src/Charts/TooltipBody.jsx
+++ b/src/Charts/TooltipBody.jsx
@@ -76,11 +76,11 @@ const fullDate = (date, granularity) => {
   if (granularity === 'week') {
     const startDate = momentDate
       .clone()
-      .startOf('week')
+      .startOf('isoWeek')
       .format('MMM D');
     const endDate = momentDate
       .clone()
-      .endOf('week')
+      .endOf('isoWeek')
       .format('MMM D, YYYY');
     return `${startDate} - ${endDate}`;
   }

--- a/src/Charts/TooltipBodyTime.jsx
+++ b/src/Charts/TooltipBodyTime.jsx
@@ -83,11 +83,11 @@ const fullDate = (date, granularity) => {
   if (granularity === 'week') {
     const startDate = momentDate
       .clone()
-      .startOf('week')
+      .startOf('isoWeek')
       .format('MMM D');
     const endDate = momentDate
       .clone()
-      .endOf('week')
+      .endOf('isoWeek')
       .format('MMM D, YYYY');
     return `${startDate} - ${endDate}`;
   }

--- a/src/Charts/utils/dateHelpers.js
+++ b/src/Charts/utils/dateHelpers.js
@@ -3,13 +3,7 @@ import moment from 'moment';
 //  time ranges relative to current day
 const today = () => [moment.utc().startOf('day'), moment.utc().endOf('day')];
 
-const thisWeek = () => [
-  moment
-    .utc()
-    .startOf('week')
-    .add(1, 'day'),
-  moment.utc()
-];
+const thisWeek = () => [moment.utc().startOf('isoWeek'), moment.utc()];
 
 const thisMonth = () => [moment.utc().startOf('month'), moment.utc()];
 
@@ -31,13 +25,11 @@ const lastWeek = () => [
   moment
     .utc()
     .subtract(1, 'week')
-    .startOf('week')
-    .add(1, 'day'),
+    .startOf('isoWeek'),
   moment
     .utc()
     .subtract(1, 'week')
-    .endOf('week')
-    .add(1, 'day')
+    .endOf('isoWeek')
 ];
 
 const lastMonth = () => [


### PR DESCRIPTION
## Brief context on code (tell us why these changes are necessary)
The data coming back for `week` granularities in the dashboard are using the isoWeek timeframe which is monday-sunday weeks, but the tooltips for week granularities were still referencing sunday-saturday weeks causing a mismatch of displayed dates in the chart vs the tooltip. 

This also updates dateHelpers to reference `isoWeek` instead of referencing `week` and then adding a day. This change will make it more explicit and consistent with the other changes made in this PR.

## Test plan
Add `granularity='week'` props to both `<TooltipBody />` and `<TooltipBodyTime />` components in the different graph stories and ensure that the tooltip displays week granularities match the isoWeek pattern of monday - sunday week.
## Before asking for code review

- [ ] I have unit tested behavioral changes
- [x] I have verified test plan works
- [x] I have merged the base branch into this branch
- [ ] I have ensured that CI is passing
- [x] I have filled out the "Brief context on code" and "Test plan" sections above
- [x] I have updated the version in package.json
