### PR TITLE
Add shortened currency formatter for payment reporting graph axis

### DIFF
--- a/build/Charts/Legend.js
+++ b/build/Charts/Legend.js
@@ -1,4 +1,6 @@
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 

--- a/build/Charts/ReportCard.js
+++ b/build/Charts/ReportCard.js
@@ -1,6 +1,8 @@
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 

--- a/build/Charts/utils/aggregators.js
+++ b/build/Charts/utils/aggregators.js
@@ -46,8 +46,8 @@ export var rowTotal = function rowTotal(row, dataKeys) {
     _iteratorError = err;
   } finally {
     try {
-      if (!_iteratorNormalCompletion && _iterator.return != null) {
-        _iterator.return();
+      if (!_iteratorNormalCompletion && _iterator["return"] != null) {
+        _iterator["return"]();
       }
     } finally {
       if (_didIteratorError) {
@@ -80,8 +80,8 @@ export var rowAvg = function rowAvg(row, dataKeys) {
     _iteratorError2 = err;
   } finally {
     try {
-      if (!_iteratorNormalCompletion2 && _iterator2.return != null) {
-        _iterator2.return();
+      if (!_iteratorNormalCompletion2 && _iterator2["return"] != null) {
+        _iterator2["return"]();
       }
     } finally {
       if (_didIteratorError2) {
@@ -126,8 +126,8 @@ export var rowWeightedAvg = function rowWeightedAvg(row, dataKeys, options) {
     _iteratorError3 = err;
   } finally {
     try {
-      if (!_iteratorNormalCompletion3 && _iterator3.return != null) {
-        _iterator3.return();
+      if (!_iteratorNormalCompletion3 && _iterator3["return"] != null) {
+        _iterator3["return"]();
       }
     } finally {
       if (_didIteratorError3) {
@@ -177,8 +177,8 @@ export var datasetAvg = function datasetAvg(data, dataKeys) {
         _iteratorError5 = err;
       } finally {
         try {
-          if (!_iteratorNormalCompletion5 && _iterator5.return != null) {
-            _iterator5.return();
+          if (!_iteratorNormalCompletion5 && _iterator5["return"] != null) {
+            _iterator5["return"]();
           }
         } finally {
           if (_didIteratorError5) {
@@ -192,8 +192,8 @@ export var datasetAvg = function datasetAvg(data, dataKeys) {
     _iteratorError4 = err;
   } finally {
     try {
-      if (!_iteratorNormalCompletion4 && _iterator4.return != null) {
-        _iterator4.return();
+      if (!_iteratorNormalCompletion4 && _iterator4["return"] != null) {
+        _iterator4["return"]();
       }
     } finally {
       if (_didIteratorError4) {
@@ -240,8 +240,8 @@ export var datasetWeightedAvg = function datasetWeightedAvg(data, dataKeys, opti
         _iteratorError7 = err;
       } finally {
         try {
-          if (!_iteratorNormalCompletion7 && _iterator7.return != null) {
-            _iterator7.return();
+          if (!_iteratorNormalCompletion7 && _iterator7["return"] != null) {
+            _iterator7["return"]();
           }
         } finally {
           if (_didIteratorError7) {
@@ -255,8 +255,8 @@ export var datasetWeightedAvg = function datasetWeightedAvg(data, dataKeys, opti
     _iteratorError6 = err;
   } finally {
     try {
-      if (!_iteratorNormalCompletion6 && _iterator6.return != null) {
-        _iterator6.return();
+      if (!_iteratorNormalCompletion6 && _iterator6["return"] != null) {
+        _iterator6["return"]();
       }
     } finally {
       if (_didIteratorError6) {

--- a/build/Charts/utils/chartHelpers.js
+++ b/build/Charts/utils/chartHelpers.js
@@ -2,7 +2,7 @@ function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArra
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
 
-function _iterableToArrayLimit(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+function _iterableToArrayLimit(arr, i) { if (!(Symbol.iterator in Object(arr) || Object.prototype.toString.call(arr) === "[object Arguments]")) { return; } var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 

--- a/build/Charts/utils/formatters.js
+++ b/build/Charts/utils/formatters.js
@@ -124,7 +124,7 @@ export var currencyRounded = function currencyRounded(pennies) {
 };
 export var currencyRoundedAndShortened = function currencyRoundedAndShortened(pennies) {
   if (pennies.toString().indexOf('.') !== -1) {
-    throw new TypeError('Input must be an integer. Value provided: '.concat(pennies));
+    throw new TypeError("Input must be an integer. Value provided: ".concat(pennies));
   }
 
   var dollars = pennies / 100;
@@ -132,25 +132,25 @@ export var currencyRoundedAndShortened = function currencyRoundedAndShortened(pe
 
   if (roundedDollars >= 0 && roundedDollars <= 999) {
     return "$".concat(commatize(roundedDollars));
-  } else {
-    var newValue = roundedDollars;
-    var suffixes = ['', 'K', 'M', 'B', 'T'];
-    var suffixNum = 0;
-
-    while (newValue >= 1000) {
-      newValue /= 1000;
-      suffixNum++;
-    }
-
-    newValue = newValue.toFixed(1);
-
-    if (newValue.length >= 4) {
-      newValue = Math.round(newValue);
-    }
-
-    newValue += suffixes[suffixNum];
-    return "$".concat(commatize(newValue));
   }
+
+  var newValue = roundedDollars;
+  var suffixes = ['', 'K', 'M', 'B', 'T'];
+  var suffixNum = 0;
+
+  while (newValue >= 1000) {
+    newValue /= 1000;
+    suffixNum++;
+  }
+
+  newValue = newValue.toFixed(1);
+
+  if (newValue.length >= 4) {
+    newValue = Math.round(newValue);
+  }
+
+  newValue += suffixes[suffixNum];
+  return "$".concat(commatize(newValue));
 };
 export default {
   abbreviateNumber: abbreviateNumber,

--- a/build/Charts/utils/formatters.js
+++ b/build/Charts/utils/formatters.js
@@ -131,8 +131,8 @@ export var currencyRoundedAndShortened = function currencyRoundedAndShortened(pe
   var roundedDollars = Math.round(dollars);
 
   if (roundedDollars >= 0 && roundedDollars <= 999) {
-    return '$'.concat(commatize(roundedDollars));
-  } else if (roundedDollars >= 1000) {
+    return "$".concat(commatize(roundedDollars));
+  } else {
     var newValue = roundedDollars;
     var suffixes = ['', 'K', 'M', 'B', 'T'];
     var suffixNum = 0;
@@ -149,7 +149,7 @@ export var currencyRoundedAndShortened = function currencyRoundedAndShortened(pe
     }
 
     newValue += suffixes[suffixNum];
-    return '$'.concat(newValue);
+    return "$".concat(commatize(newValue));
   }
 };
 export default {

--- a/build/Charts/utils/formatters.js
+++ b/build/Charts/utils/formatters.js
@@ -26,8 +26,8 @@ export var roundToPlaces = function roundToPlaces(places) {
     return commatize(roundedNumber.toString());
   };
 };
-export function secondsToMinutes(int) {
-  return commatize(Math.round(int / 60));
+export function secondsToMinutes(_int) {
+  return commatize(Math.round(_int / 60));
 }
 export function capitalize(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
@@ -122,6 +122,36 @@ export var currencyRounded = function currencyRounded(pennies) {
   var roundedDollars = Math.round(dollars);
   return "$".concat(commatize(roundedDollars));
 };
+export var currencyRoundedAndShortened = function currencyRoundedAndShortened(pennies) {
+  if (pennies.toString().indexOf('.') !== -1) {
+    throw new TypeError('Input must be an integer. Value provided: '.concat(pennies));
+  }
+
+  var dollars = pennies / 100;
+  var roundedDollars = Math.round(dollars);
+
+  if (roundedDollars >= 0 && roundedDollars <= 999) {
+    return '$'.concat(commatize(roundedDollars));
+  } else if (roundedDollars >= 1000) {
+    var newValue = roundedDollars;
+    var suffixes = ['', 'K', 'M', 'B', 'T'];
+    var suffixNum = 0;
+
+    while (newValue >= 1000) {
+      newValue /= 1000;
+      suffixNum++;
+    }
+
+    newValue = newValue.toFixed(1);
+
+    if (newValue.length >= 4) {
+      newValue = Math.round(newValue);
+    }
+
+    newValue += suffixes[suffixNum];
+    return '$'.concat(newValue);
+  }
+};
 export default {
   abbreviateNumber: abbreviateNumber,
   abbreviateTime: abbreviateTime,
@@ -134,5 +164,6 @@ export default {
   secondsToMinutes: secondsToMinutes,
   roundToPlaces: roundToPlaces,
   currency: currency,
-  currencyRounded: currencyRounded
+  currencyRounded: currencyRounded,
+  currencyRoundedAndShortened: currencyRoundedAndShortened
 };

--- a/build/Charts/utils/transformer.js
+++ b/build/Charts/utils/transformer.js
@@ -1,4 +1,6 @@
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 

--- a/build/Stories/storyHelpers.js
+++ b/build/Stories/storyHelpers.js
@@ -16,7 +16,9 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podium-reporting-toolkit",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A collection of Podium's reporting platform and charting components built in React.",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/src/Charts/utils/formatters.js
+++ b/src/Charts/utils/formatters.js
@@ -125,31 +125,28 @@ export const currencyRounded = pennies => {
 };
 export const currencyRoundedAndShortened = pennies => {
   if (pennies.toString().indexOf('.') !== -1) {
-    throw new TypeError(
-      'Input must be an integer. Value provided: '.concat(pennies)
-    );
+    throw new TypeError(`Input must be an integer. Value provided: ${pennies}`);
   }
 
   const dollars = pennies / 100;
   const roundedDollars = Math.round(dollars);
   if (roundedDollars >= 0 && roundedDollars <= 999) {
     return `$${commatize(roundedDollars)}`;
-  } else {
-    let newValue = roundedDollars;
-    const suffixes = ['', 'K', 'M', 'B', 'T'];
-    let suffixNum = 0;
-
-    while (newValue >= 1000) {
-      newValue /= 1000;
-      suffixNum++;
-    }
-    newValue = newValue.toFixed(1);
-    if (newValue.length >= 4) {
-      newValue = Math.round(newValue);
-    }
-    newValue += suffixes[suffixNum];
-    return `$${commatize(newValue)}`;
   }
+  let newValue = roundedDollars;
+  const suffixes = ['', 'K', 'M', 'B', 'T'];
+  let suffixNum = 0;
+
+  while (newValue >= 1000) {
+    newValue /= 1000;
+    suffixNum++;
+  }
+  newValue = newValue.toFixed(1);
+  if (newValue.length >= 4) {
+    newValue = Math.round(newValue);
+  }
+  newValue += suffixes[suffixNum];
+  return `$${commatize(newValue)}`;
 };
 
 export default {

--- a/src/Charts/utils/formatters.js
+++ b/src/Charts/utils/formatters.js
@@ -123,6 +123,36 @@ export const currencyRounded = pennies => {
 
   return `$${commatize(roundedDollars)}`;
 };
+export var currencyRoundedAndShortened = function currencyRoundedAndShortened(
+  pennies
+) {
+  if (pennies.toString().indexOf('.') !== -1) {
+    throw new TypeError(
+      'Input must be an integer. Value provided: '.concat(pennies)
+    );
+  }
+
+  var dollars = pennies / 100;
+  var roundedDollars = Math.round(dollars);
+  if (roundedDollars >= 0 && roundedDollars <= 999) {
+    return '$'.concat(commatize(roundedDollars));
+  } else if (roundedDollars >= 1000) {
+    var newValue = roundedDollars;
+    var suffixes = ['', 'K', 'M', 'B', 'T'];
+    var suffixNum = 0;
+
+    while (newValue >= 1000) {
+      newValue /= 1000;
+      suffixNum++;
+    }
+    newValue = newValue.toFixed(1);
+    if (newValue.length >= 4) {
+      newValue = Math.round(newValue);
+    }
+    newValue += suffixes[suffixNum];
+    return '$'.concat(newValue);
+  }
+};
 
 export default {
   abbreviateNumber,
@@ -136,5 +166,6 @@ export default {
   secondsToMinutes,
   roundToPlaces,
   currency,
-  currencyRounded
+  currencyRounded,
+  currencyRoundedAndShortened
 };

--- a/src/Charts/utils/formatters.js
+++ b/src/Charts/utils/formatters.js
@@ -123,23 +123,21 @@ export const currencyRounded = pennies => {
 
   return `$${commatize(roundedDollars)}`;
 };
-export var currencyRoundedAndShortened = function currencyRoundedAndShortened(
-  pennies
-) {
+export const currencyRoundedAndShortened = pennies => {
   if (pennies.toString().indexOf('.') !== -1) {
     throw new TypeError(
       'Input must be an integer. Value provided: '.concat(pennies)
     );
   }
 
-  var dollars = pennies / 100;
-  var roundedDollars = Math.round(dollars);
+  const dollars = pennies / 100;
+  const roundedDollars = Math.round(dollars);
   if (roundedDollars >= 0 && roundedDollars <= 999) {
-    return '$'.concat(commatize(roundedDollars));
-  } else if (roundedDollars >= 1000) {
-    var newValue = roundedDollars;
-    var suffixes = ['', 'K', 'M', 'B', 'T'];
-    var suffixNum = 0;
+    return `$${commatize(roundedDollars)}`;
+  } else {
+    let newValue = roundedDollars;
+    const suffixes = ['', 'K', 'M', 'B', 'T'];
+    let suffixNum = 0;
 
     while (newValue >= 1000) {
       newValue /= 1000;
@@ -150,7 +148,7 @@ export var currencyRoundedAndShortened = function currencyRoundedAndShortened(
       newValue = Math.round(newValue);
     }
     newValue += suffixes[suffixNum];
-    return '$'.concat(newValue);
+    return `$${commatize(newValue)}`;
   }
 };
 

--- a/src/__tests__/formatters.test.js
+++ b/src/__tests__/formatters.test.js
@@ -3,7 +3,8 @@ import {
   commatize,
   nullToValue,
   currency,
-  currencyRounded
+  currencyRounded,
+  currencyRoundedAndShortened
 } from '../Charts/utils/formatters';
 
 describe('formatters', () => {
@@ -84,6 +85,52 @@ describe('formatters', () => {
     it('should throw an error with malformed input', () => {
       expect(() => {
         currencyRounded(1.23);
+      }).toThrow(`Input must be an integer. Value provided: 1.23`);
+    });
+  });
+
+  describe('currencyRoundedAndShortened', () => {
+    it('should round to the nearest dollar and display whole number for numbers $0-999', () => {
+      let result = currencyRoundedAndShortened(12345);
+      expect(result).toEqual('$123');
+      result = currencyRoundedAndShortened(0);
+      expect(result).toEqual('$0');
+      result = currencyRoundedAndShortened(10);
+      expect(result).toEqual('$0');
+      result = currencyRoundedAndShortened(99900);
+      expect(result).toEqual('$999');
+      result = currencyRoundedAndShortened(99949);
+      expect(result).toEqual('$999');
+      result = currencyRoundedAndShortened(56051);
+      expect(result).toEqual('$561');
+      result = currencyRoundedAndShortened(100);
+      expect(result).toEqual('$1');
+    });
+
+    it('should round to the nearest whole dollar and display 1 decimal place starting at 1.0K and above', () => {
+      let result = currencyRoundedAndShortened(123456789);
+      expect(result).toEqual('$1.2M');
+      result = currencyRoundedAndShortened(99999);
+      expect(result).toEqual('$1.0K');
+      result = currencyRoundedAndShortened(100000);
+      expect(result).toEqual('$1.0K');
+      result = currencyRoundedAndShortened(120000);
+      expect(result).toEqual('$1.2K');
+      result = currencyRoundedAndShortened(23545678);
+      expect(result).toEqual('$236K');
+      result = currencyRoundedAndShortened(12345678900);
+      expect(result).toEqual('$124M');
+      result = currencyRoundedAndShortened(123456789000);
+      expect(result).toEqual('$1.2B');
+      result = currencyRoundedAndShortened(523456789000000);
+      expect(result).toEqual('$5.2T');
+      result = currencyRoundedAndShortened(52300000000000);
+      expect(result).toEqual('$523B');
+    });
+
+    it('should throw an error with malformed input', () => {
+      expect(() => {
+        currencyRoundedAndShortened(1.23);
       }).toThrow(`Input must be an integer. Value provided: 1.23`);
     });
   });


### PR DESCRIPTION
## Brief context on code (tell us why these changes are necessary)
We need a formatter for currency that is more condensed for the y-axis on the payment amount processed graph.  The condensed formatter will format in the following way:
$0-999 will just have round to the nearest $
$1000-99000 will display in the format $1.0K - $99.0K
$100,00.... will display in the format $100K

basically we will only have a max of 3 digits in the number depending on what the number is.

## Test plan
Run tests

## Before asking for code review

- [x] I have unit tested behavioral changes
- [x] I have verified test plan works
- [x] I have merged the base branch into this branch
- [x] I have ensured that CI is passing
- [x] I have filled out the "Brief context on code" and "Test plan" sections above
- [x] I have updated the version in package.json
