### PR TITLE
Story stateful report card

### DIFF
--- a/build/Stories/ReportCard.story.js
+++ b/build/Stories/ReportCard.story.js
@@ -554,4 +554,84 @@ storiesOf('Report Card', module).add('w/Chart,Title', function () {
     dateStart: "2018-12-05",
     dateEnd: "2019-01-10"
   }));
+}).add('Changing time ranges', function () {
+  return React.createElement(Controller, null, function (chartData, legendData) {
+    return React.createElement(ReportCard, null, React.createElement(ReportTitle, {
+      title: "Inbound Leads by Source",
+      timeRange: "custom",
+      dateStart: "2018-09-15T23:43:32",
+      dateEnd: "2018-11-15T23:43:32"
+    }), React.createElement(Chart, {
+      data: chartData
+    }, React.createElement(YAxis, null), React.createElement(XAxis, {
+      dataKey: "date",
+      tickFormatter: formatters.date()
+    }), React.createElement(Line, {
+      dataKey: "dogs.cuteness",
+      name: "Dogs",
+      color: colors.cobaltBlue
+    }), React.createElement(Line, {
+      dataKey: "cats.cuteness",
+      name: "Cats",
+      color: colors.poppyRed
+    }), React.createElement(Tooltip, {
+      content: React.createElement(TooltipBody, {
+        formatter: formatters.roundToPlaces(1),
+        aggregationOptions: {
+          type: 'weightedAvg',
+          dataKeys: ['dogs', 'cats'],
+          options: {
+            valueKey: 'cuteness',
+            countKey: 'amount'
+          }
+        },
+        summaryTitle: "Animals"
+      })
+    })), React.createElement(Summary, {
+      formatter: formatters.roundToPlaces(1),
+      chartData: chartData,
+      aggregationOptions: {
+        type: 'weightedAvg',
+        dataKeys: ['cats', 'dogs'],
+        options: {
+          valueKey: 'cuteness',
+          countKey: 'amount'
+        }
+      },
+      overallSummaryMetric: 3.5,
+      granularity: "month",
+      timeRange: "lastYear"
+    }), React.createElement(Legend, {
+      formatter: formatters.roundToPlaces(1),
+      legendData: legendData,
+      aggregationOptions: {
+        type: 'weightedAvg',
+        dataKeys: ['cats', 'dogs'],
+        options: {
+          valueKey: 'cuteness',
+          countKey: 'amount'
+        }
+      },
+      displayOptions: [{
+        name: 'Dogs',
+        dataKey: 'dogs',
+        color: colors.cobaltBlue
+      }, {
+        name: 'Cats',
+        dataKey: 'cats',
+        color: colors.poppyRed
+      }]
+    }));
+  });
 });
+
+function Controller(_ref) {
+  var children = _ref.children;
+  var chartData = weightedAvgData;
+  var legendData = weightedAvgDataLegend;
+  return React.createElement("div", null, React.createElement("p", null, React.createElement("button", {
+    onClick: function onClick() {}
+  }, "Sep - Oct"), React.createElement("button", {
+    onClick: function onClick() {}
+  }, "Oct - Nov")), React.createElement("div", null, children(chartData, legendData)));
+}

--- a/build/Stories/ReportCard.story.js
+++ b/build/Stories/ReportCard.story.js
@@ -1,4 +1,12 @@
-import React from 'react';
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
+
+function _iterableToArrayLimit(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import formatters from '../Charts/utils/formatters';
 import colors from '../Colors';
@@ -555,12 +563,12 @@ storiesOf('Report Card', module).add('w/Chart,Title', function () {
     dateEnd: "2019-01-10"
   }));
 }).add('Changing time ranges', function () {
-  return React.createElement(Controller, null, function (chartData, legendData) {
+  return React.createElement(Controller, null, function (chartData, legendData, dateRange) {
     return React.createElement(ReportCard, null, React.createElement(ReportTitle, {
       title: "Inbound Leads by Source",
       timeRange: "custom",
-      dateStart: "2018-09-15T23:43:32",
-      dateEnd: "2018-11-15T23:43:32"
+      dateStart: dateRange.startDate,
+      dateEnd: dateRange.endDate
     }), React.createElement(Chart, {
       data: chartData
     }, React.createElement(YAxis, null), React.createElement(XAxis, {
@@ -600,7 +608,7 @@ storiesOf('Report Card', module).add('w/Chart,Title', function () {
       },
       overallSummaryMetric: 3.5,
       granularity: "month",
-      timeRange: "lastYear"
+      timeRange: "custom"
     }), React.createElement(Legend, {
       formatter: formatters.roundToPlaces(1),
       legendData: legendData,
@@ -627,11 +635,40 @@ storiesOf('Report Card', module).add('w/Chart,Title', function () {
 
 function Controller(_ref) {
   var children = _ref.children;
-  var chartData = weightedAvgData;
   var legendData = weightedAvgDataLegend;
+  var septOctChartData = weightedAvgData.slice(0, 2);
+  var octNovChartData = weightedAvgData.slice(1, 3);
+  var septOctDateRange = {
+    startDate: '2018-09-01T00:00:00',
+    endDate: '2018-10-31T23:59:59'
+  };
+  var octNovDateRange = {
+    startDate: '2018-10-01T00:00:00',
+    endDate: '2018-11-30T23:59:59'
+  };
+
+  var _useState = useState(septOctDateRange),
+      _useState2 = _slicedToArray(_useState, 2),
+      dateRange = _useState2[0],
+      setDateRange = _useState2[1];
+
+  var _useState3 = useState(septOctChartData),
+      _useState4 = _slicedToArray(_useState3, 2),
+      chartData = _useState4[0],
+      setChartData = _useState4[1];
+
+  var updateStates = function updateStates(dateRange, data) {
+    setDateRange(dateRange);
+    setChartData(data);
+  };
+
   return React.createElement("div", null, React.createElement("p", null, React.createElement("button", {
-    onClick: function onClick() {}
+    onClick: function onClick() {
+      updateStates(septOctDateRange, septOctChartData);
+    }
   }, "Sep - Oct"), React.createElement("button", {
-    onClick: function onClick() {}
-  }, "Oct - Nov")), React.createElement("div", null, children(chartData, legendData)));
+    onClick: function onClick() {
+      updateStates(octNovDateRange, octNovChartData);
+    }
+  }, "Oct - Nov")), React.createElement("div", null, children(chartData, legendData, dateRange)));
 }

--- a/build/Stories/ReportCardHelpers/StatefulReportCard.js
+++ b/build/Stories/ReportCardHelpers/StatefulReportCard.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function StatefulReportCard() {
+  return React.createElement("div", null, "StatefulReportCard");
+}
+
+export default StatefulReportCard;

--- a/build/Stories/ReportCardHelpers/index.js
+++ b/build/Stories/ReportCardHelpers/index.js
@@ -1,1 +1,2 @@
 export { default as CustomLegendNotes } from './CustomLegendNotes.md';
+export { default as StatefulReportCard } from './StatefulReportCard.jsx';

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "lodash.get": "^4.4.2",
     "lodash.groupby": "^4.6.0",
     "lodash.set": "^4.3.2",
-    "recharts": "^1.6.1"
+    "recharts": "^1.8.5"
   },
   "peerDependencies": {
     "@podiumhq/podium-ui": "^16.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podium-reporting-toolkit",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A collection of Podium's reporting platform and charting components built in React.",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/src/Stories/ReportCard.story.jsx
+++ b/src/Stories/ReportCard.story.jsx
@@ -487,4 +487,81 @@ storiesOf('Report Card', module)
         dateEnd="2019-01-10"
       />
     </ReportCard>
+  ))
+
+  .add('Changing time ranges', () => (
+    <Controller>
+      {(chartData, legendData) => (
+        <ReportCard>
+          <ReportTitle
+            title="Inbound Leads by Source"
+            timeRange="custom"
+            dateStart="2018-09-15T23:43:32"
+            dateEnd="2018-11-15T23:43:32"
+          />
+          <Chart data={chartData}>
+            <YAxis />
+            <XAxis dataKey="date" tickFormatter={formatters.date()} />
+            <Line
+              dataKey="dogs.cuteness"
+              name="Dogs"
+              color={colors.cobaltBlue}
+            />
+            <Line dataKey="cats.cuteness" name="Cats" color={colors.poppyRed} />
+            <Tooltip
+              content={
+                <TooltipBody
+                  formatter={formatters.roundToPlaces(1)}
+                  aggregationOptions={{
+                    type: 'weightedAvg',
+                    dataKeys: ['dogs', 'cats'],
+                    options: { valueKey: 'cuteness', countKey: 'amount' }
+                  }}
+                  summaryTitle="Animals"
+                />
+              }
+            />
+          </Chart>
+          <Summary
+            formatter={formatters.roundToPlaces(1)}
+            chartData={chartData}
+            aggregationOptions={{
+              type: 'weightedAvg',
+              dataKeys: ['cats', 'dogs'],
+              options: { valueKey: 'cuteness', countKey: 'amount' }
+            }}
+            overallSummaryMetric={3.5}
+            granularity="month"
+            timeRange="lastYear"
+          />
+          <Legend
+            formatter={formatters.roundToPlaces(1)}
+            legendData={legendData}
+            aggregationOptions={{
+              type: 'weightedAvg',
+              dataKeys: ['cats', 'dogs'],
+              options: { valueKey: 'cuteness', countKey: 'amount' }
+            }}
+            displayOptions={[
+              { name: 'Dogs', dataKey: 'dogs', color: colors.cobaltBlue },
+              { name: 'Cats', dataKey: 'cats', color: colors.poppyRed }
+            ]}
+          />
+        </ReportCard>
+      )}
+    </Controller>
   ));
+
+function Controller({ children }) {
+  const chartData = weightedAvgData;
+  const legendData = weightedAvgDataLegend;
+  return (
+    <div>
+      <p>
+        <button onClick={() => {}}>Sep - Oct</button>
+        <button onClick={() => {}}>Oct - Nov</button>
+      </p>
+      <div>{children(chartData, legendData)}</div>
+    </div>
+  );
+}

--- a/src/Stories/ReportCard.story.jsx
+++ b/src/Stories/ReportCard.story.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import formatters from '../Charts/utils/formatters';
 import colors from '../Colors';
@@ -491,13 +491,13 @@ storiesOf('Report Card', module)
 
   .add('Changing time ranges', () => (
     <Controller>
-      {(chartData, legendData) => (
+      {(chartData, legendData, dateRange) => (
         <ReportCard>
           <ReportTitle
             title="Inbound Leads by Source"
             timeRange="custom"
-            dateStart="2018-09-15T23:43:32"
-            dateEnd="2018-11-15T23:43:32"
+            dateStart={dateRange.startDate}
+            dateEnd={dateRange.endDate}
           />
           <Chart data={chartData}>
             <YAxis />
@@ -532,7 +532,7 @@ storiesOf('Report Card', module)
             }}
             overallSummaryMetric={3.5}
             granularity="month"
-            timeRange="lastYear"
+            timeRange="custom"
           />
           <Legend
             formatter={formatters.roundToPlaces(1)}
@@ -553,15 +553,42 @@ storiesOf('Report Card', module)
   ));
 
 function Controller({ children }) {
-  const chartData = weightedAvgData;
   const legendData = weightedAvgDataLegend;
+  const septOctChartData = weightedAvgData.slice(0, 2);
+  const octNovChartData = weightedAvgData.slice(1, 3);
+  const septOctDateRange = {
+    startDate: '2018-09-01T00:00:00',
+    endDate: '2018-10-31T23:59:59'
+  };
+  const octNovDateRange = {
+    startDate: '2018-10-01T00:00:00',
+    endDate: '2018-11-30T23:59:59'
+  };
+  const [dateRange, setDateRange] = useState(septOctDateRange);
+  const [chartData, setChartData] = useState(septOctChartData);
+  const updateStates = (dateRange, data) => {
+    setDateRange(dateRange);
+    setChartData(data);
+  };
   return (
     <div>
       <p>
-        <button onClick={() => {}}>Sep - Oct</button>
-        <button onClick={() => {}}>Oct - Nov</button>
+        <button
+          onClick={() => {
+            updateStates(septOctDateRange, septOctChartData);
+          }}
+        >
+          Sep - Oct
+        </button>
+        <button
+          onClick={() => {
+            updateStates(octNovDateRange, octNovChartData);
+          }}
+        >
+          Oct - Nov
+        </button>
       </p>
-      <div>{children(chartData, legendData)}</div>
+      <div>{children(chartData, legendData, dateRange)}</div>
     </div>
   );
 }

--- a/src/Stories/ReportCardHelpers/StatefulReportCard.jsx
+++ b/src/Stories/ReportCardHelpers/StatefulReportCard.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function StatefulReportCard() {
+  return <div>StatefulReportCard</div>;
+}
+
+export default StatefulReportCard;

--- a/src/Stories/ReportCardHelpers/index.js
+++ b/src/Stories/ReportCardHelpers/index.js
@@ -1,1 +1,2 @@
 export { default as CustomLegendNotes } from './CustomLegendNotes.md';
+export { default as StatefulReportCard } from './StatefulReportCard.jsx';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3673,10 +3673,10 @@ core-js@^2.2.2, core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.7, 
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
-core-js@^2.5.1:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.7.tgz#c2b19af9b50ec49c356ee087d6155632a889e968"
-  integrity sha512-ydmsQxDVH7lDpYoirXft8S83ddKKfdsrsmWhtyj7xafXVLbLhKOyfD7kAi2ueFfeP7m9rNavjW59O3hLLzzC5A==
+core-js@^2.6.10:
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
+  integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -9556,10 +9556,10 @@ react-resize-detector@^3.2.1:
     prop-types "^15.6.2"
     resize-observer-polyfill "^1.5.1"
 
-react-smooth@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/react-smooth/-/react-smooth-1.0.2.tgz#f7a2d932ece8db898646078c3c97f3e9533e0486"
-  integrity sha512-pIGzL1g9VGAsRsdZQokIK0vrCkcdKtnOnS1gyB2rrowdLy69lNSWoIjCTWAfgbiYvria8tm5hEZqj+jwXMkV4A==
+react-smooth@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/react-smooth/-/react-smooth-1.0.5.tgz#94ae161d7951cdd893ccb7099d031d342cb762ad"
+  integrity sha512-eW057HT0lFgCKh8ilr0y2JaH2YbNcuEdFpxyg7Gf/qDKk9hqGMyXryZJ8iMGJEuKH0+wxS0ccSsBBB3W8yCn8w==
   dependencies:
     lodash "~4.17.4"
     prop-types "^15.6.0"
@@ -9740,20 +9740,20 @@ recharts-scale@^0.4.2:
   dependencies:
     decimal.js-light "^2.4.1"
 
-recharts@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/recharts/-/recharts-1.6.1.tgz#ed505d07ae3ed323443b5387d71254171e62fb2c"
-  integrity sha512-w1rpdE2CCe/0DmtTONaN3wslmGtHsC15aneIMy2GDUqPKldUweEug89Kh9sD/zyq7lGU9zQiXwMPr6dyjQ9JOg==
+recharts@1.8.5:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/recharts/-/recharts-1.8.5.tgz#ca94a3395550946334a802e35004ceb2583fdb12"
+  integrity sha512-tM9mprJbXVEBxjM7zHsIy6Cc41oO/pVYqyAsOHLxlJrbNBuLs0PHB3iys2M+RqCF0//k8nJtZF6X6swSkWY3tg==
   dependencies:
     classnames "^2.2.5"
-    core-js "^2.5.1"
+    core-js "^2.6.10"
     d3-interpolate "^1.3.0"
     d3-scale "^2.1.0"
     d3-shape "^1.2.0"
     lodash "^4.17.5"
     prop-types "^15.6.0"
     react-resize-detector "^2.3.0"
-    react-smooth "^1.0.0"
+    react-smooth "^1.0.5"
     recharts-scale "^0.4.2"
     reduce-css-calc "^1.3.0"
 


### PR DESCRIPTION
## Brief context on code (tell us why these changes are necessary)
There was a bug with recharts version 1.8.1 where the chart axes didn't update if the data changed. This PR adds a story that allows for changing state/data, and then bumps the version number if recharts.
## Test plan
Change the package.json recharts version to `1.8.1` and run `yarn install`. Then check the `Changing time ranges` report card story. When you change the range, the axes will not update. Then change the version back to `^1.8.5` and check the same story. It should now correctly update the axes. 
## Before asking for code review

- [ ] I have unit tested behavioral changes
- [x] I have verified test plan works
- [x] I have merged the base branch into this branch
- [x] I have ensured that CI is passing
- [x] I have filled out the "Brief context on code" and "Test plan" sections above
- [x] I have updated the version in package.json
